### PR TITLE
Pspec cherry changes in pspec_oqe_2d and src/oqe.py

### DIFF
--- a/pspec_pipeline/pspec_oqe_2d.py
+++ b/pspec_pipeline/pspec_oqe_2d.py
@@ -497,12 +497,23 @@ if opts.frf:
         #nij = n.tile(data_dict_n[key].flatten(), 3).reshape((3*size,nchan)) # add padding
         nij = data_dict_n[key].copy()
         wij = n.ones(nij.shape, dtype=bool)
+        fir_size = fir.values()[0].shape[1]
+        if size < fir_size:
+            diff = fir_size - size
+            nij = n.pad(nij, (diff,0), mode='constant', constant_values=0)
+            nij = nij[:,diff:]
+            wij = n.ones_like(nij)
+        else:
+            diff = None
         if conj_dict[key[1]] is True: # apply frf using the conj of data and the conj fir
             nij_frf = fringe_rate_filter(aa, n.conj(nij), wij, ij[0], ij[1], POL, bins, fir_conj)
         else:
             nij_frf = fringe_rate_filter(aa, nij, wij, ij[0], ij[1], POL, bins, fir)
         #data_dict_n[key] = nij_frf[size:2*size,:]
-        data_dict_n[key] = nij_frf.copy()
+        if diff:
+            data_dict_n[key] = nij_frf[diff:].copy()
+        else:
+            data_dict_n[key] = nij_frf.copy()
 
 # Set data
 if opts.changeC:

--- a/src/oqe.py
+++ b/src/oqe.py
@@ -283,8 +283,9 @@ class DataSet:
                 Ixsum[newkey] = sum([self.x[(s,bl,POL)] for bl in gps[gp]])
                 dsC_data[newkey] = np.dot(np.linalg.inv(iCsum[newkey]),iCxsum[newkey]).T #finding effective summed up x based on iCsum and iCxsum
                 dsI_data[newkey] = np.dot(np.linalg.inv(Isum[newkey]),Ixsum[newkey]).T #finding effective summed up x based on Isum and Ixsum
-        dsC = DataSet(); dsC.set_data(dsets=dsC_data)
-        dsI = DataSet(); dsI.set_data(dsets=dsI_data) #I has to be a separate dataset because it has different x's populated into it
+        obj_class = self.__class__
+        dsC = obj_class(); dsC.set_data(dsets=dsC_data)
+        dsI = obj_class(); dsI.set_data(dsets=dsI_data) #I has to be a separate dataset because it has different x's populated into it
         dsC.set_iC(iCsum) #override since if they're computed from x, they're incorrect
         dsI.set_I(Isum)
         if use_cov: return newkeys, dsC


### PR DESCRIPTION
changed pspec_oqe_2d:

if the length of lsts is less than the size of the FRF, it pads the noise array before filtering then re-selects it's original shape when it is saved to a data set.

src/oqe.py

re-assigns the DataSet() instantiation in group_data to be self.__class__. This way if you sublass DataSet the new grouped data will be the new subclass not the old super clsas