### PR TITLE
Frf conjugation fix

### DIFF
--- a/pspec_pipeline/frf_filter.py
+++ b/pspec_pipeline/frf_filter.py
@@ -2,7 +2,7 @@
 
 import aipy as a
 import capo.arp as arp
-import capo.frf_conv as fringe
+from capo import fringe
 import capo.zsa as zsa
 import capo as C
 import numpy as n

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,4 @@
 import pfb, pspec, dspec, red, fringe, miriad, linsolve, xrfi
-import fringe as frf_conv # for backward compatibility
 import oqe, hex, metrics
 import warnings
 import eor_results

--- a/src/fringe.py
+++ b/src/fringe.py
@@ -166,8 +166,6 @@ def apply_frf(aa, data, wgts, i, j, pol='I', firs=None, alietal=False,
     datf,wgtf = n.zeros_like(data), n.zeros_like(data)
     fir = firs[(i,j,pol)]
     for ch in xrange(nchan):
-        #datf[:,ch] = n.convolve(data[:,ch], fir[ch,:], mode='same')
-        #wgtf[:,ch] = n.convolve(wgts[:,ch], n.abs(fir[ch,:]), mode='same')
         datf[:,ch] = n.convolve(data[:,ch]*wgts[:,ch], fir[ch,:], mode='same')
         wgtf[:,ch] = n.convolve(wgts[:,ch], n.abs(fir[ch,:]), mode='same')
     datf = n.where(wgtf > 0, datf/wgtf, 0)

--- a/src/fringe.py
+++ b/src/fringe.py
@@ -168,7 +168,7 @@ def apply_frf(aa, data, wgts, i, j, pol='I', firs=None, alietal=False,
     for ch in xrange(nchan):
         #datf[:,ch] = n.convolve(data[:,ch], fir[ch,:], mode='same')
         #wgtf[:,ch] = n.convolve(wgts[:,ch], n.abs(fir[ch,:]), mode='same')
-        datf[:,ch] = n.convolve(data[:,ch]*wgts[:,ch], n.conj(fir[ch,:]), mode='same')
-        wgtf[:,ch] = n.convolve(wgts[:,ch], n.abs(n.conj(fir[ch,:])), mode='same')
+        datf[:,ch] = n.convolve(data[:,ch]*wgts[:,ch], fir[ch,:], mode='same')
+        wgtf[:,ch] = n.convolve(wgts[:,ch], n.abs(fir[ch,:]), mode='same')
     datf = n.where(wgtf > 0, datf/wgtf, 0)
     return datf, wgtf, tbins, firs


### PR DESCRIPTION
Removed the n.conj(firs) call inside of capo.fringe.frf_apply. This conjugation caused fringe-rate filters to filter the negative fringe-rates of the desired ones.


Hmm it looks like **ALL** the axes are flipped, but I'm pretty sure that is a plotting error not the data. Let me know if you want me to remake the plots.

Here are foregrounds in file as a base comparison: 
![psa64_7_12_foregrounds](https://user-images.githubusercontent.com/8646829/42836859-0a8fc1f2-89b1-11e8-8161-c7ff86f35b6d.png)

Foregrounds in data filtered with the current version mkolopanis/pspec_jackfruit:src/fringe.py: 
![psa64_7_12_old_frf](https://user-images.githubusercontent.com/8646829/42836862-13c3ce1c-89b1-11e8-8f58-9287018df618.png)

Foregrounds in data filtered with the changes in this branch: 
![psa64_7_12_new_frf](https://user-images.githubusercontent.com/8646829/42836869-1e7f22de-89b1-11e8-848d-d17b6b85a7e5.png)

I ran through pspec_oqe_2d.py to check too and I think things are working correctly there. Here's the foreground in data plotted through pspec_oqe_2d: 
![pspec_oqe_unfiltered_data](https://user-images.githubusercontent.com/8646829/42836908-41404f0a-89b1-11e8-8186-87e56e4fcf64.png)

and the eor_injection in the older version of pspec_oqe_2d:
![pspec_oqe_old_inject](https://user-images.githubusercontent.com/8646829/42836930-4fcd5784-89b1-11e8-9189-6d5fa9a8c1a1.png)


This is the eor_inject with the changes in this branch:
![pspec_oqe_new_inject](https://user-images.githubusercontent.com/8646829/42836945-5ee9f7c2-89b1-11e8-86de-d5887dbd07de.png)

and the data in pspec_oqe_2d in the new branch;
![pspec_oqe_new_filter_data](https://user-images.githubusercontent.com/8646829/42836959-688747d0-89b1-11e8-833c-814ed5eb6d37.png)



